### PR TITLE
Use Node.js callback convention, don't throw errors in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ var kraken = require('kraken-api');
 var client = new kraken('api_key', 'api_secret');
 
 // Display user's balance
-client.api('Balance', null, function(response) {
+client.api('Balance', null, function(error, response) {
 	console.log('Balances:', response.result);
 });
 ```

--- a/kraken.js
+++ b/kraken.js
@@ -125,16 +125,19 @@ function KrakenClient(key, secret, otp) {
 		};
 
 		var req = request.post(options, function(error, response, body) {
-			if(error) {
-				throw new Error('Error in server response: ' + JSON.stringify(error));
-			}
-			else if(typeof callback === 'function') {
+			if(typeof callback === 'function') {
+				if (error) {
+					callback.call(self, new Error('Error in server response: ' + JSON.stringify(error)));
+				}
+
+				var data;
 				try {
-					callback.call(self, JSON.parse(body));
+					data = JSON.parse(body);
+				} catch(e) {
+					return callback.call(self, new Error('Could not understand response from server: ' + body));
 				}
-				catch(e) {
-					throw new Error('Could not understand response from server.');
-				}
+				
+				callback.call(self, null, data);
 			}
 		});
 


### PR DESCRIPTION
Hi there,

This patch changes your callbacks to follow the Node.js convention of `function (error, result)`. It's a breaking change, but better to do now if you want to follow the convention.

Also you we're throwing errors in the HTTP callback - this crashes the node process. These errors are now passed to the new-style callback instead.

Sean
