### PR TITLE
Pass errors to the callback instead of throwing.

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -130,14 +130,16 @@ function KrakenClient(key, secret, otp) {
 				var data;
 
 				if(error) {
-					throw new Error('Error in server response: ' + JSON.stringify(error));
+					callback.call(self, new Error('Error in server response: ' + JSON.stringify(error)), null);
+					return;
 				}
 
 				try {
 					data = JSON.parse(body);
 				}
 				catch(e) {
-					throw new Error('Could not understand response from server: ' + body);
+					callback.call(self, new Error('Could not understand response from server: ' + body), null);
+					return;
 				}
 
 				if(data.error && data.error.length) {


### PR DESCRIPTION
The commit 7b2e1d45a2bf17796755131df1cce6721d7d19ff introduced the throwing of errors instead passing them to the callback.

There is no way to catch these for api consumers. As soon as the kraken api returns invalid json the whole process goes down because of the uncatched error.

This pull request passes the errors to the callback as recommended by Node conventions and allows them to be handled.
