### PR TITLE
increment the nonce on each api call

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -10,6 +10,7 @@ var querystring	= require('querystring');
  */
 function KrakenClient(key, secret, otp) {
 	var self = this;
+	var nonce = new Date() * 1000; // spoof microsecond
 
 	var config = {
 		url: 'https://api.kraken.com',
@@ -72,7 +73,7 @@ function KrakenClient(key, secret, otp) {
 		var path	= '/' + config.version + '/private/' + method;
 		var url		= config.url + path;
 
-		params.nonce = new Date() * 1000; // spoof microsecond
+		params.nonce = nonce++
 
 		if(config.otp !== undefined) {
 			params.otp = config.otp;


### PR DESCRIPTION
The current approach of using the date as the nonce means two calls made inside one second will have the later call fail due to using the same none. I came across this almost immediately when using this package.

Taking a tip from the 'nonce' npm package, its more usable to start with the current time, then add one for each http call to ensure no collisions in the nonce while saying strictly incrementing. 
