### PR TITLE
Cover error case

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -155,6 +155,8 @@ function KrakenClient(key, secret, otp) {
 					});
 					if (krakenError) {
 						return callback.call(self, new Error('Kraken API returned error: ' + krakenError), null);
+					} else {
+						return callback.call(self, new Error('Kraken API returned an unknown error'), null);	
 					}
 				}
 				else {


### PR DESCRIPTION
If for some reason the Kraken API returns an error in an unexpected format, this change ensures that it will not fail silently, but propagate an unknown error.