### PR TITLE
Make timeout configurable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+declare module "kraken-api" {
+    type Command = "Balance"| "TradeBalance"| "OpenOrders"| "ClosedOrders"| "QueryOrders"| "TradesHistory"|
+        "QueryTrades"| "OpenPositions"| "Ledgers"| "QueryLedgers"| "TradeVolume"| "AddOrder"| "CancelOrder"|
+        "DepositMethods"| "DepositAddresses"| "DepositStatus"| "WithdrawInfo"| "Withdraw"| "WithdrawStatus"|
+        "WithdrawCancel"
+
+    type Callback = (error: Error, success: any) => any
+
+    class KrakenClient {
+        constructor(key: string, secret: string, otp?: string, timeoutMs?: number)
+        public api(command: Command, payload: object, cb?: Callback): void
+    }
+
+    export = KrakenClient
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,13 @@ declare module "kraken-api" {
 
     type Callback = (error: Error, success: any) => any
 
+    interface Options {
+        otp?: string
+        timeoutMs?: number
+    }
+
     class KrakenClient {
-        constructor(key: string, secret: string, otp?: string, timeoutMs?: number)
+        constructor(key: string, secret: string, options?: Options)
         public api(command: Command, payload: object, cb?: Callback): void
     }
 

--- a/kraken.js
+++ b/kraken.js
@@ -6,10 +6,9 @@ var querystring	= require('querystring');
  * KrakenClient connects to the Kraken.com API
  * @param {String} key    API Key
  * @param {String} secret API Secret
- * @param {String} [otp]  Two-factor password (optional) (also, doesn't work)
- * @param {Number} [timeoutMs]  Request timeout in milliseconds (optional)
+ * @param {Object} [options]  Configuration object (can contain opt {String} (optional), timeoutMs {Number} (optional))
  */
-function KrakenClient(key, secret, otp, timeoutMs) {
+function KrakenClient(key, secret, options) {
 	var self = this;
 
 	var config = {
@@ -17,8 +16,8 @@ function KrakenClient(key, secret, otp, timeoutMs) {
 		version: '0',
 		key: key,
 		secret: secret,
-		otp: otp,
-		timeoutMs: timeoutMs || 5000
+		otp: options.otp,
+		timeoutMs: options && options.timeoutMs || 5000
 	};
 
 	/**

--- a/kraken.js
+++ b/kraken.js
@@ -7,6 +7,7 @@ var querystring	= require('querystring');
  * @param {String} key    API Key
  * @param {String} secret API Secret
  * @param {String} [otp]  Two-factor password (optional) (also, doesn't work)
+ * @param {Number} [timeoutMs]  Request timeout in milliseconds (optional)
  */
 function KrakenClient(key, secret, otp, timeoutMs) {
 	var self = this;

--- a/kraken.js
+++ b/kraken.js
@@ -8,7 +8,7 @@ var querystring	= require('querystring');
  * @param {String} secret API Secret
  * @param {String} [otp]  Two-factor password (optional) (also, doesn't work)
  */
-function KrakenClient(key, secret, otp) {
+function KrakenClient(key, secret, otp, timeoutMs) {
 	var self = this;
 
 	var config = {
@@ -17,7 +17,7 @@ function KrakenClient(key, secret, otp) {
 		key: key,
 		secret: secret,
 		otp: otp,
-		timeoutMS: 5000
+		timeoutMs: timeoutMs || 5000
 	};
 
 	/**
@@ -126,7 +126,7 @@ function KrakenClient(key, secret, otp) {
 			method: 'POST',
 			headers: headers,
 			form: params,
-			timeout: config.timeoutMS
+			timeout: config.timeoutMs
 		};
 
 		var req = request.post(options, function(error, response, body) {
@@ -165,9 +165,9 @@ function KrakenClient(key, secret, otp) {
 		return req;
 	}
 
-	self.api			= api;
+	self.api = api;
 	self.publicMethod	= publicMethod;
-	self.privateMethod	= privateMethod;
+	self.privateMethod = privateMethod;
 }
 
 module.exports = KrakenClient;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kraken-api",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "kraken.com API client library for NodeJS",
   "keywords": [
     "kraken",


### PR DESCRIPTION
I encountered multiple issues with the default timeout of 5s (also see #27). 

This pull request changes the constructor to optionally take an object which allows passing in the optional parameters `otp` and `timeoutMs`.

Usage example:
```javascript
new KrakenClient(this.key, this.secret, { timeoutMs: 8000 })
```

Also I added type definitions to use this library with typescript.