### PR TITLE
Increase default timeout to 30 seconds

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -12,7 +12,7 @@ const methods = {
 const defaults = {
 	url     : 'https://api.kraken.com',
 	version : 0,
-	timeout : 5000,
+	timeout : 10000,
 };
 
 // Create a signature for a request

--- a/kraken.js
+++ b/kraken.js
@@ -12,7 +12,7 @@ const methods = {
 const defaults = {
 	url     : 'https://api.kraken.com',
 	version : 0,
-	timeout : 10000,
+	timeout : 30000,
 };
 
 // Create a signature for a request


### PR DESCRIPTION
I've had timeout errors on orders with timeouts under 30 seconds. The orders go through and the transaction id's are lost unless you try to go find them.