### PR TITLE
Update the error manager

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -43,15 +43,20 @@ const rawRequest = async (url, headers, data, timeout) => {
 	const response = JSON.parse(body);
 
 	if(response.error && response.error.length) {
-		const error = response.error
-			.filter((e) => e.startsWith('E'))
+		const error = response.error;
+		if(typeof error === 'object') {
+			error.filter((e) => e.startsWith('E'))
 			.map((e) => e.substr(1));
 
-		if(!error.length) {
-			throw new Error("Kraken API returned an unknown error");
-		}
+			if(!error.length) {
+				throw new Error("Kraken API returned an unknown error");
+			}
 
-		throw new Error(error.join(', '));
+			throw new Error(error.join(', '));
+		}
+		else {
+			throw new Error(error);
+		}
 	}
 
 	return response;


### PR DESCRIPTION
To prevent "UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: response.error.filter is not a function" when the error is "Error: EFunding:No funding method"