### PR TITLE
fix Error: API:Invalid nonce

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -149,7 +149,7 @@ class KrakenClient {
 		const url  = this.config.url + path;
 
 		if(!params.nonce) {
-			params.nonce = new Date() * 1000; // spoof microsecond
+			params.nonce = new Date() * 1000000; // spoof microsecond
 		}
 
 		if(this.config.otp !== undefined) {


### PR DESCRIPTION
The example returns an API error complaining about the nonce, this change will fix it.