### PR TITLE
always overwrite nonce

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -148,9 +148,7 @@ class KrakenClient {
 		const path = '/' + this.config.version + '/private/' + method;
 		const url  = this.config.url + path;
 
-		if(!params.nonce) {
-			params.nonce = new Date() * 1000; // spoof microsecond
-		}
+		params.nonce = new Date() * 1000; // spoof microsecond
 
 		if(this.config.otp !== undefined) {
 			params.otp = this.config.otp;


### PR DESCRIPTION
Currently you can pass a nonce in the params object and this lib will use it. If you don't it will mutate the params object by attaching a nonce.

However my retry mechanism passes the params object to this lib multiple times (in case of kraken API errors). And since this lib adds the nonce the first time, the second time this nonce gets reused resulting in "Invalid nonce" since it's using the same nonce it used the first time.

This hot fixes that, always overwriting the nonce property every call.

Better solution would be to not attach the nonce property to the params object passed from userland.

I was using this lib in my project called Gekko, but I will be using my fork until this is merged.