### PR TITLE
Fix deprecated Buffer() usage

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -18,7 +18,7 @@ const defaults = {
 // Create a signature for a request
 const getMessageSignature = (path, request, secret, nonce) => {
 	const message       = qs.stringify(request);
-	const secret_buffer = new Buffer(secret, 'base64');
+	const secret_buffer = Buffer.from(secret, 'base64');
 	const hash          = new crypto.createHash('sha256');
 	const hmac          = new crypto.createHmac('sha512', secret_buffer);
 	const hash_digest   = hash.update(nonce + message).digest('binary');


### PR DESCRIPTION
This usage of `Buffer` is deprecated in Node 10; see [here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) for more details. It causes the following warning:

> (node:3277) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

This change fixes the warning.